### PR TITLE
Fix broken top navigation links

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -36,8 +36,8 @@
           <ul class="nav navbar-nav">
             {% if page.category == 'home' %}<li class="active"><a href="/">home</a></li>{% else %}<li><a href="/">home</a></li>{% endif %}
             {% if page.category == 'news' %}<li class="active"><a href="/news/">news</a></li>{% else %}<li><a href="/news/">news</a></li>{% endif %}
-            {% if page.category == 'watch' %}<li class="active"><a href="/watch.html">watch</a></li>{% else %}<li><a href="/watch.html">watch</a></li>{% endif %}
-            {% if page.category == 'learn' %}<li class="active"><a href="/learn.html">learn</a></li>{% else %}<li><a href="/learn.html">learn</a></li>{% endif %}
+            {% if page.category == 'watch' %}<li class="active"><a href="/watch/">watch</a></li>{% else %}<li><a href="/watch/">watch</a></li>{% endif %}
+            {% if page.category == 'learn' %}<li class="active"><a href="/learn/">learn</a></li>{% else %}<li><a href="/learn/">learn</a></li>{% endif %}
             <li><a href="https://github.com/nerves-project">code</a></li>
           </ul>
         </div><!--/.nav-collapse -->


### PR DESCRIPTION
Hey, just want to let you know that the top navigation links for 'Watch' and 'Learn' are broken.
Currently, it's pointing to `/watch.html` instead of `/watch`.

This PR fixes it. Cheers.